### PR TITLE
Fix: add generate key method for reloading button component on loading | disabled

### DIFF
--- a/src/components/Button/ButtonFrom.vue
+++ b/src/components/Button/ButtonFrom.vue
@@ -27,17 +27,19 @@ const props = withDefaults(defineProps<Props>(), {
   overrides: () => ({}),
 });
 
+const bindProps = computed(() => {
+  if (!props.action) {
+    return {};
+  }
+
+  const { onAction, content, ...other } = props.action;
+
+  return { ...other, ...props.overrides };
+});
+
 const handleClick = () => {
   if (props.action && props.action.onAction) {
     props.action.onAction();
   }
 };
-
-const bindProps = computed(() => {
-  if (!props.action) {
-    return {};
-  }
-  const { onAction, content, ...other } = props.action;
-  return { ...other, ...props.overrides };
-});
 </script>

--- a/src/components/Button/ButtonMarkup.vue
+++ b/src/components/Button/ButtonMarkup.vue
@@ -16,8 +16,8 @@ UnstyledButton(
       Icon(:source="loading ? 'placeholder': icon")
     span(
       v-if="children",
-      :class="childrenClass",
       :key="actionProps && actionProps.disabled ? 'text-disabled' : 'text'",
+      :class="childrenClass",
     )
       slot
     span(
@@ -68,12 +68,15 @@ const attrs = useAttrs();
 const listeners = computed(() => {
   const events = ['blur', 'click', 'focus', 'keydown', 'keypress', 'keyup', 'mouseover', 'touchstart', 'pointerdown'];
   const eventBindings: Record<string, unknown> = {};
+
   for (const event of events) {
     const eventName = `on${capitalize(event)}`;
+
     if (attrs[eventName]) {
       eventBindings[event] = attrs[eventName];
     }
   }
+
   return eventBindings;
 });
 


### PR DESCRIPTION
- Cause: loading and disabled props only change button styles -> button won't update
- Solution: add generate key method for updating component everytime disabled|loading props change

- Test with page actions component
- Test with normal button component
- Test with build command