### PR TITLE
allow user to set _blank for Link component

### DIFF
--- a/src/components/UnstyledLink/UnstyledLink.vue
+++ b/src/components/UnstyledLink/UnstyledLink.vue
@@ -7,7 +7,7 @@ router-link(
 a(
   v-else,
   :href="url",
-  :target="to ? '_blank' : undefined",
+  :target="external ? '_blank' : undefined",
   :rel="external ? 'noopener noreferrer' : undefined",
 )
   <!-- Slot for displaying content inside the link -->


### PR DESCRIPTION
I could not set _blank on my `Link` because this 'to' flag is reused in two places: line 3 with the v-if, and line 10 for setting _blank.

If I set 'to' to some value, then `router-link` gets returned.

If I set 'to' to undefined, then 'a' gets returned, but _blank does not get set.

So there is no way to set _blank.

How to fix?

Based on my reading, the most likely correct expression should've been based on 'external', not 'to'.

Feel free to correct me.