### PR TITLE
Fix incorrect import path for locales in documentation

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -94,7 +94,7 @@ The `i18n` prop is required to pass the locales, you can check the [supported lo
   </AppProvider>
 </template>
 <script setup>
-import locales from '@ownego/polaris-vue/locales/en.json';
+import locales from '@ownego/polaris-vue/dist/locales/en.json';
 </script>
 ```
 :::


### PR DESCRIPTION
I have updated the import statement to the correct path, @ownego/polaris-vue/dist/locales/en.json, ensuring that the example accurately guides users in importing locales from the distributed package. This change will help prevent confusion and potential errors for developers integrating internationalization features.