### PR TITLE
useThemeName support string

### DIFF
--- a/src/use/useTheme.ts
+++ b/src/use/useTheme.ts
@@ -16,7 +16,7 @@ export default function useTheme() {
 export function useThemeName() {
   const themeName = inject<ComputedRef<ThemeName>>('themeName');
 
-  if (!themeName || !themeName.value) {
+  if (!themeName) {
     throw new Error(
       'No themeName was provided.'
     );


### PR DESCRIPTION
sometimes themeName is like ref but sometimes  theneName is like 'string'. When I debug in browser , I find this issue.

For try you can use the combobox component

 <Combobox allowMultiple>
    <template #activator>
     <!-- If you can use any input component in there , you will get themeName was not provider -->
        <template #prefix>
          <Icon :source="SearchIcon" />
        </template>
      </ComboboxTextField>
    </template>
     </Combobox>