### PR TITLE
Fix inverted if in tabs

### DIFF
--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -41,7 +41,7 @@ div(:class="styles.Outer")
             @toggle-popover="handleTogglePopover",
           )
           li(
-            v-if="breakpoints.mdDown || tabsToShow.length === 0",
+            v-if="!(breakpoints.mdDown || tabsToShow.length === 0)",
             role="presentation",
             :class="disclosureTabClassName",
           )


### PR DESCRIPTION
Hello,

In the original react implementation this condition returns null

https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/Tabs/Tabs.tsx#L577

In the vue implementation, the same condition is rendering the "More views" button.

In practice this button does not show up, because when we are on the breakpoint mdDown, all tabs are inside of a scrollable wrapper.