### PR TITLE
fix: Tab item missing className

### DIFF
--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -21,22 +21,22 @@ div(:class="styles.Outer")
           data-tabs-focus-catchment,
         )
           Tab(
-            v-for="_tab, index in tabData",
-            v-bind="tabs[index]",
+            v-for="tabIndex in tabData",
+            v-bind="tabs[tabIndex]",
             ref=`${index === selected ? selectedTabRef : null}`,
-            :actions="tabs[index].actions",
-            :key="`${index}-${tabs[index].id}`",
-            :id="tabs[index].id"
-            :panelID="hasSlot(slots.default) ? tabs[index].panelID || `${tabs[index].id}-panel` : undefined",
-            :disabled="disabled || tabs[index].disabled",
+            :actions="tabs[tabIndex].actions",
+            :key="`${tabIndex}-${tabs[tabIndex].id}`",
+            :id="tabs[tabIndex].id"
+            :panelID="hasSlot(slots.default) ? tabs[tabIndex].panelID || `${tabs[tabIndex].id}-panel` : undefined",
+            :disabled="disabled || tabs[tabIndex].disabled",
             :siblingTabHasFocus="state.tabToFocus > -1",
-            :focused="index === state.tabToFocus",
-            :selected="index === selected",
-            :accessibilityLabel="tabs[index].accessibilityLabel"
-            :url="tabs[index].url",
-            :content="tabs[index].content",
+            :focused="tabIndex === state.tabToFocus",
+            :selected="tabIndex === selected",
+            :accessibilityLabel="tabs[tabIndex].accessibilityLabel"
+            :url="tabs[tabIndex].url",
+            :content="tabs[tabIndex].content",
             :viewNames="viewNames",
-            @tab-action="() => { handleTabClick(tabs[index].id) }",
+            @tab-action="() => { handleTabClick(tabs[tabIndex].id) }",
             @toggle-modal="handleToggleModal",
             @toggle-popover="handleTogglePopover",
           )

--- a/src/components/Tabs/components/Item/Item.vue
+++ b/src/components/Tabs/components/Item/Item.vue
@@ -63,7 +63,7 @@ const classname = computed(() => classNames(styles.Item));
 
 const sharedProps = computed(() => ({
   id: props.id,
-  class: classname.value,
+  className: classname.value,
   'aria-selected': false,
   'aria-label': props.accessibilityLabel,
 }));

--- a/src/components/Tabs/components/Item/Item.vue
+++ b/src/components/Tabs/components/Item/Item.vue
@@ -63,7 +63,7 @@ const classname = computed(() => classNames(styles.Item));
 
 const sharedProps = computed(() => ({
   id: props.id,
-  className: classname,
+  class: classname.value,
   'aria-selected': false,
   'aria-label': props.accessibilityLabel,
 }));


### PR DESCRIPTION
Hello,

After my last pull request #382, i realize that the item tabs were missing their respective class property. This pr fix that.
Sorry for having two seperate pull request for such small issues. I delayed this one for some days in case something else was discovered.

![image](https://github.com/user-attachments/assets/1e654733-2149-42fd-9362-f401f84dfc20)
![Captura de ecrã de 2024-07-31 17-19-14](https://github.com/user-attachments/assets/861595f9-b957-4986-b337-ff814372dc11)
