### PR TITLE
fix: update Select to use model instead of value for native select's binded value

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -18,7 +18,7 @@ Labelled(
     select(
       :id="`${id}`",
       :name="name",
-      :value="value",
+      :value="model",
       :class="styles.Input",
       :disabled="disabled",
       :aria-invalid="Boolean(error)",


### PR DESCRIPTION
**See related Issue:** https://github.com/ownego/polaris-vue/issues/386

>I noticed this in docs, as well as locally.
>
>Visually it looks like the Select is working, but the native `select` element's value is being reset, or set to an empty string.
>
>Only on the second time of clicking the option will it get set properly.
![Kapture 2024-08-08 at 15 57 58](https://github.com/user-attachments/assets/d7f387f7-dc1b-4679-8f59-5aa504a619fe)


Changing `:value="value"` to `:value="model"` seems to get things working correctly. See below with the local docs being run.

![Kapture 2024-08-08 at 18 10 27](https://github.com/user-attachments/assets/d5b6f827-3fa8-473b-9e2a-c29ce0a6d81b)
