### PR TITLE
Fix: wrong emits value for isSticky variable in Sticky.vue

### DIFF
--- a/src/components/Sticky/Sticky.vue
+++ b/src/components/Sticky/Sticky.vue
@@ -69,7 +69,7 @@ const handlePositioning = (
     adjustPlaceHolderNode(stick);
     isSticky.value = !isSticky.value;
 
-    emits('sticky-change', isSticky.value);
+    emits('sticky-change', !isSticky.value);
 
     if (!props.boundingElement) {
       return;


### PR DESCRIPTION
Polaris version:
![Screenshot 2024-09-04 at 15 58 56](https://github.com/user-attachments/assets/08745956-960e-4b59-abaa-dd566b7e0ce7)

React version:
![Screenshot 2024-09-04 at 15 59 11](https://github.com/user-attachments/assets/9801e590-8a98-4cd1-ba9e-260e200aa440)

Old version of Polaris emits wrong value