### PR TITLE
fix: export props types  of each component

### DIFF
--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,1 +1,2 @@
 export { default as Badge } from './Badge.vue';
+export * from './types';

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -3,3 +3,4 @@ export { default as BannerLayout } from './components/BannerLayout.vue';
 export { default as DefaultBanner} from './components/DefaultBanner.vue';
 export { default as InlineIconBanner } from './components/InlineIconBanner.vue';
 export { default as WithinContentContainerBanner } from './components/WithinContentContainerBanner.vue';
+export * from './types';

--- a/src/components/BlockStack/index.ts
+++ b/src/components/BlockStack/index.ts
@@ -1,1 +1,2 @@
 export { default as BlockStack } from './BlockStack.vue';
+export * from './types';

--- a/src/components/Box/index.ts
+++ b/src/components/Box/index.ts
@@ -1,1 +1,2 @@
 export { default as Box } from './Box.vue';
+export * from './types';

--- a/src/components/BulkActions/index.ts
+++ b/src/components/BulkActions/index.ts
@@ -1,1 +1,2 @@
 export { default as BulkActions } from './BulkActions.vue';
+export * from './types';

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button.vue';
 export { default as ButtonFrom } from './ButtonFrom.vue';
+export * from './types';

--- a/src/components/ButtonGroup/index.ts
+++ b/src/components/ButtonGroup/index.ts
@@ -1,2 +1,3 @@
 export { default as ButtonGroup } from './ButtonGroup.vue';
 export { Item as ButtonGroupItem } from './components';
+export * from './types';

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,1 +1,2 @@
 export { default as Card } from './Card.vue';
+export * from './types';

--- a/src/components/CheckableButton/index.ts
+++ b/src/components/CheckableButton/index.ts
@@ -1,2 +1,3 @@
 export { default as CheckableButton } from './CheckableButton.vue';
 export type { CheckableButtonProps } from './types';
+export * from './types';

--- a/src/components/Choice/index.ts
+++ b/src/components/Choice/index.ts
@@ -1,1 +1,2 @@
 export { default as Choice } from './Choice.vue';
+export * from './types';

--- a/src/components/ChoiceList/index.ts
+++ b/src/components/ChoiceList/index.ts
@@ -1,1 +1,2 @@
 export { default as ChoiceList } from './ChoiceList.vue';
+export * from './types';

--- a/src/components/Collapsible/index.ts
+++ b/src/components/Collapsible/index.ts
@@ -1,1 +1,2 @@
 export { default as Collapsible } from './Collapsible.vue';
+export * from './types';

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -1,1 +1,2 @@
 export { default as DataTable } from './DataTable.vue';
+export * from './types';

--- a/src/components/ExceptionList/index.ts
+++ b/src/components/ExceptionList/index.ts
@@ -1,1 +1,2 @@
 export { default as ExceptionList } from './ExceptionList.vue';
+export * from './types';

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,1 +1,2 @@
 export { default as Icon } from './Icon.vue';
+export * from './type';

--- a/src/components/IndexFilters/index.ts
+++ b/src/components/IndexFilters/index.ts
@@ -1,2 +1,3 @@
 export { default as IndexFilters } from './IndexFilters.vue';
 export { IndexFiltersMode } from './types';
+export * from './types';

--- a/src/components/IndexProvider/index.ts
+++ b/src/components/IndexProvider/index.ts
@@ -1,1 +1,2 @@
 export { default as IndexProvider } from './IndexProvider.vue';
+export * from './types';

--- a/src/components/IndexTable/index.ts
+++ b/src/components/IndexTable/index.ts
@@ -1,3 +1,4 @@
 export { default as IndexTable } from './IndexTable.vue';
 export { default as IndexTableRow } from './components/Row/Row.vue';
 export { default as IndexTableCell } from './components/Cell/Cell.vue';
+export * from './types';

--- a/src/components/InlineGrid/index.ts
+++ b/src/components/InlineGrid/index.ts
@@ -1,1 +1,2 @@
 export { default as InlineGrid } from './InlineGrid.vue';
+export * from './types';

--- a/src/components/InlineStack/index.ts
+++ b/src/components/InlineStack/index.ts
@@ -1,1 +1,2 @@
 export { default as InlineStack } from './InlineStack.vue'
+export * from './types';

--- a/src/components/Labelled/index.ts
+++ b/src/components/Labelled/index.ts
@@ -1,1 +1,2 @@
 export { default as Labelled } from './Labelled.vue';
+export * from './types';

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,1 +1,2 @@
 export { default as Link } from './Link.vue';
+export * from './types';

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,1 +1,2 @@
 export { default as Pagination } from './Pagination.vue';
+export * from './types';

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,3 +1,4 @@
 export { default as Popover } from './Popover.vue';
 export * from './components';
 export type { PopoverProps } from './types';
+export * from './types';

--- a/src/components/PositionedOverlay/index.ts
+++ b/src/components/PositionedOverlay/index.ts
@@ -1,1 +1,2 @@
 export { default as PositionedOverlay } from './PositionedOverlay.vue';
+export * from './types';

--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -1,1 +1,2 @@
 export { default as RadioButton } from './RadioButton.vue';
+export * from './types';

--- a/src/components/RangeSlider/index.ts
+++ b/src/components/RangeSlider/index.ts
@@ -1,1 +1,2 @@
 export { default as RangeSlider } from './RangeSlider.vue';
+export * from './types';

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,1 +1,2 @@
 export { default as Select } from './Select.vue';
+export * from './types';

--- a/src/components/ShadowBevel/index.ts
+++ b/src/components/ShadowBevel/index.ts
@@ -1,1 +1,2 @@
 export { default as ShadowBevel } from './ShadowBevel.vue';
+export * from './types';

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,1 +1,2 @@
 export { default as Tabs } from './Tabs.vue';
+export * from './types';

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,2 +1,3 @@
 
 export { default as Text } from './Text.vue';
+export * from './types';

--- a/src/components/TextField/index.ts
+++ b/src/components/TextField/index.ts
@@ -1,1 +1,2 @@
 export { default as TextField } from './TextField.vue';
+export * from './types';

--- a/src/components/ThemeProvider/index.ts
+++ b/src/components/ThemeProvider/index.ts
@@ -1,1 +1,2 @@
 export { default as ThemeProvider } from './ThemeProvider.vue';
+export * from './types';

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,2 +1,3 @@
 export { default as Tooltip } from './Tooltip.vue';
 export * from './components';
+export * from './types';

--- a/src/components/VideoThumbnail/index.ts
+++ b/src/components/VideoThumbnail/index.ts
@@ -1,1 +1,2 @@
 export { default as VideoThumbnail } from './VideoThumbnail.vue';
+export * from './types';


### PR DESCRIPTION
# Export Component Types for Improved TypeScript Support

## Overview
This pull request proposes exporting the TypeScript types for all components in the polaris-vue library. This change aims to enhance the developer experience when using the library with TypeScript, without affecting the bundle size or runtime performance.

## Changes Made
- Updated `index.ts` files to export types from their respective `types.ts` files
- Example:
  ```typescript
  export { default as VideoThumbnail } from './VideoThumbnail.vue';
  export * from './types';
  ```

## Benefits
1. **Improved Developer Experience**: Developers can easily access and use the component prop types without extra steps.

2. **Type Safety**: Direct access to types reduces the chance of prop-related errors and improves code quality.

3. **Autocomplete and IntelliSense**: IDEs can provide better suggestions and type information, speeding up development.

4. **No Bundle Size Impact**: Exporting types doesn't affect the final bundle size as TypeScript types are removed during compilation.

5. **Consistency with TypeScript Best Practices**: Many popular component libraries export their types, aligning with community standards.

## Current vs Proposed Usage
Currently, developers need to extract types like this:
```vue
<script setup lang="ts">
import { Button } from '@ownego/polaris-vue'
type ButtonProperties = InstanceType<typeof Button>['$props']
</script>
``` 

With this change, they could directly use the exported types:
```typescript
import { type IndexTableHeading, IndexTable } from '@ownego/polaris-vue';
```

## Additional Considerations
- This change maintains backward compatibility.
- It aligns the library more closely with TypeScript ecosystem expectations.
- It could reduce the number of issues related to prop-type mismatches.

Thank you for considering this pull request!

