### PR TITLE
fix: add VNode support to VueNode due to incompatible type

### DIFF
--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,10 +1,10 @@
-import type { Component, ComputedRef, Ref } from 'vue';
+import type { Component, ComputedRef, Ref, VNode } from 'vue';
 
 export type Target = '_blank' | '_self' | '_parent' | '_top';
 
 export type IconSource = Component | string | (string | Component)[]
 
-export type VueNode = string | number | boolean | Component | Element | Function | null | undefined;
+export type VueNode = string | number | boolean | Component | Element | Function | VNode | null | undefined;
 
 export type NonEmptyArray<T> = [T, ...T[]];
 


### PR DESCRIPTION
Added VNode to the VueNode type definition to include virtual nodes returned by the h() function. This change addresses warnings related to bannerTitle and bannerIcon in the component. By including VNode in the type, we improve type safety and ensure proper rendering of icons when they are conditionally displayed. 

```vue
const bannerTitle = props.title
  ? h(
    Text,
    { variant: 'headingSm', as: 'h2', breakWord: true },
    () => props.title,
  )
  : undefined;

const bannerIcon = !props.hideIcon
  ? h(
    'span',
    { class: styles[bannerColors.value.icon] },
    h(Icon, { source: props.icon || bannerAttributes[bannerTone.value].icon, }),
  )
  : undefined;

``` 