### PR TITLE
Update: fix shadow bevel binding class wrong

### DIFF
--- a/src/components/ShadowBevel/ShadowBevel.vue
+++ b/src/components/ShadowBevel/ShadowBevel.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 component(
   :is="as",
-  :className="styles.ShadowBevel",
+  :class="styles.ShadowBevel",
   :style="style",
 )
   slot


### PR DESCRIPTION
Wrong class binding when add class to Card 
`Card.test`
<img width="250" alt="Screenshot 2024-11-21 at 11 24 07" src="https://github.com/user-attachments/assets/8bd67e06-5894-466c-bfd0-0bfaf45213e4">
class `Polaris-ShadowBevel` is replaced instead of adding new class test 
-> no css of shadow in Card when add new class.