### PR TITLE
Update: Sort Button activator for popover in IndexFilters

### DIFF
--- a/src/components/IndexFilters/components/SortButton/SortButton.vue
+++ b/src/components/IndexFilters/components/SortButton/SortButton.vue
@@ -14,13 +14,13 @@ Popover(
       :hover-delay="400",
       :z-index-override="disclosureZIndexOverride",
     )
-    Button(
-      size="slim",
-      :icon="SortIcon",
-      :disabled="disabled",
-      :accessibility-label="i18n.translate('Polaris.IndexFilters.SortButton.ariaLabel')",
-      @click="handleClick",
-    )
+      Button(
+        size="slim",
+        :icon="SortIcon",
+        :disabled="disabled",
+        :accessibility-label="i18n.translate('Polaris.IndexFilters.SortButton.ariaLabel')",
+        @click="handleClick",
+      )
   Box(
     min-width="148px",
     padding-inline-start="300",


### PR DESCRIPTION
<img width="388" alt="image" src="https://github.com/user-attachments/assets/92312ae5-12b6-4c62-84ae-3479cd0dee07">
Fix wrong activator for sort button in IndexFilters