### PR TITLE
Update: custom props for checkboxes

### DIFF
--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -114,7 +114,7 @@ export interface CheckboxProps extends ChoiceBleedProps {
   error?: Error | boolean;
   /** Indicates the tone of the checkbox */
   tone?: 'magic';
-  /** custom disable focus - for case Slot use checkbox in Combobox -> focus -> close popover*/
+  /** Disable auto focus to input when click to checkbox*/
   disableFocus?: boolean;
 }
 
@@ -236,6 +236,7 @@ const handleOnClick = () => {
 
   model.value = inputNode.value.checked;
 
+  // Props use for fix case Checkbox use as slot of Combobox Component -> auto close popover when change focus
   if (!props.disableFocus) {
     inputNode.value.focus();
   }

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -114,6 +114,8 @@ export interface CheckboxProps extends ChoiceBleedProps {
   error?: Error | boolean;
   /** Indicates the tone of the checkbox */
   tone?: 'magic';
+  /** custom disable focus - for case Slot use checkbox in Combobox -> focus -> close popover*/
+  disableFocus?: boolean;
 }
 
 type CheckboxSlots = {
@@ -233,7 +235,11 @@ const handleOnClick = () => {
   }
 
   model.value = inputNode.value.checked;
-  inputNode.value.focus();
+
+  if (!props.disableFocus) {
+    inputNode.value.focus();
+  }
+
   emits('change', inputNode.value.checked, props.value || id.value);
 };
 </script>


### PR DESCRIPTION
- Disable focus for fix case use Checkbox as slot in Combobox component: When click to check box -> auto focus to input -> disable for not closing popover of Combobox component